### PR TITLE
Changes git log parameters for `gl` alias.

### DIFF
--- a/bash/bash_profile.symlink
+++ b/bash/bash_profile.symlink
@@ -39,7 +39,7 @@ alias gca='gc -a'
 alias gs='git status'
 alias ga='git add'
 alias gad='ga -A .'
-alias gl='git log'
+alias gl='git log --oneline --decorate --graph'
 
 ## Vim
 alias v='vim .'


### PR DESCRIPTION
Changes the parameters passed to git log in the `gl` alias to be based
on those recommended in the Upcase Mastering Git course.
- Changes to oneline to only display short hash and first line of commit
  message
- Uses decorate to colorize different parts of commit
- Adds graph flag. Interested to see how this can be useful in day to
  day.

This does not add the recommended `all` flag to look at all branches.
This seemed a bit like overkill to me and could possible lead to
confusion. I would like to test it out a bit in practice and see if I
can find any good use cases for it.

This also doesn't add the count limit (e.g. -30 for last 30 commits). I
do like having knowledge of that command but since it gets piped into
less `q`ing out off less seems to be cleaner than keeping around the
log.
