### PR TITLE
tmux: preserve current path when splitting panes

### DIFF
--- a/tmux/tmux.conf.symlink
+++ b/tmux/tmux.conf.symlink
@@ -28,6 +28,18 @@ set -g status-fg white
 # https://devel.tech/tips/n/tMuXm4vP/reloading-config-from-inside-tmux/
 bind-key r source-file ~/.tmux.conf \; display-message "~/.tmux.conf reloaded"
 
+#
+# Panes
+#
+
+# Pane splits should open to the same path as the current pane
+bind '"' split-window -v -c "#{pane_current_path}"
+bind % split-window -h -c "#{pane_current_path}"
+
+#
+# End Panes
+#
+
 # Numbering
 
 # Start tabs at index 1


### PR DESCRIPTION
## Summary
- Pane splits (`"` vertical, `%` horizontal) now inherit the working directory of the current pane via `-c "#{pane_current_path}"`
- Previously new splits always started at `$HOME`

## Test plan
- [ ] `Prefix + "` opens a new vertical split in the same directory
- [ ] `Prefix + %` opens a new horizontal split in the same directory
- [ ] Existing pane navigation and resizing still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)