### PR TITLE
tmux: rebind clipboard paste to uppercase P

### DIFF
--- a/tmux/tmux.conf.symlink
+++ b/tmux/tmux.conf.symlink
@@ -89,5 +89,5 @@ bind -r L resize-pane -R 5
 # Enter copy mode with Prefix + [
 bind [ copy-mode
 
-# Paste from system clipboard with Prefix + p
-bind p run-shell "pbpaste | tmux load-buffer - && tmux paste-buffer"
+# Paste from system clipboard with Prefix + P
+bind P run-shell "pbpaste | tmux load-buffer - && tmux paste-buffer"


### PR DESCRIPTION
## Summary
- Changes clipboard paste binding from `Prefix + p` to `Prefix + P`
- Frees up lowercase `p` (which conflicts with vim-style pane navigation bound to `h/j/k/l/p`)

## Test plan
- [ ] `Prefix + P` pastes from system clipboard
- [ ] Lowercase `p` is no longer bound to paste

🤖 Generated with [Claude Code](https://claude.com/claude-code)