### PR TITLE
gitignore: exclude Claude Code local state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,10 @@ config.symlink/asdf-direnv/zshrc
 node_modules
 
 **/.claude/settings.local.json
+**/.claude/worktrees
+
+# raycast - managed extension state, not user config
+config.symlink/raycast/
+
+# tidewave - all-defaults config, machine-specific
+config.symlink/tidewave/


### PR DESCRIPTION
## Summary
- Adds `.claude/worktrees` to `.gitignore` (joins `settings.local.json` which was already excluded)
- These directories contain machine-specific Claude Code session state that should not be shared

🤖 Generated with [Claude Code](https://claude.com/claude-code)