### PR TITLE
wt: checkout falls back to remote-tracking branch

### DIFF
--- a/bin/wt
+++ b/bin/wt
@@ -188,17 +188,35 @@ checkout_worktree() {
         exit 1
     fi
     
-    # Check if branch exists
-    if ! git show-ref --verify --quiet "refs/heads/$branch_name"; then
-        print_error "Branch '$branch_name' does not exist"
-        echo "Use 'wt new $branch_name' to create a new branch"
-        exit 1
+    if git show-ref --verify --quiet "refs/heads/$branch_name"; then
+        print_info "Creating worktree for existing branch '$branch_name'..."
+        git worktree add "$worktree_path" "$branch_name"
+    else
+        # No local branch — look for a matching remote-tracking branch
+        local remote_matches=()
+        local ref
+        while IFS= read -r ref; do
+            if [[ "${ref#*/}" == "$branch_name" ]]; then
+                remote_matches+=("$ref")
+            fi
+        done < <(git for-each-ref --format='%(refname:short)' refs/remotes/)
+
+        if [[ ${#remote_matches[@]} -eq 0 ]]; then
+            print_error "Branch '$branch_name' does not exist"
+            echo "Use 'wt new $branch_name' to create a new branch"
+            exit 1
+        elif [[ ${#remote_matches[@]} -gt 1 ]]; then
+            print_error "Multiple remotes have a branch named '$branch_name':"
+            printf '  %s\n' "${remote_matches[@]}" >&2
+            echo "Specify the remote explicitly, e.g. 'wt checkout <remote>/$branch_name'" >&2
+            exit 1
+        fi
+
+        local remote_branch="${remote_matches[0]}"
+        print_info "Creating worktree for new branch '$branch_name' tracking '$remote_branch'..."
+        git worktree add --track -b "$branch_name" "$worktree_path" "$remote_branch"
     fi
-    
-    # Create the worktree for existing branch
-    print_info "Creating worktree for existing branch '$branch_name'..."
-    git worktree add "$worktree_path" "$branch_name"
-    
+
     print_success "Created worktree at: $worktree_path"
     echo "cd \"$worktree_path\""
 }
@@ -264,6 +282,8 @@ Commands:
   wt new <branch-name>      Create a new branch and worktree
   wt checkout [branch-name] Create a worktree for an existing branch
                            (interactive selection with fzf if no branch specified)
+                           If the branch only exists on a remote, a local
+                           tracking branch is created automatically.
   wt list                   List all worktrees for the current project
   wt remove [branch-name]   Remove a worktree
                            (interactive selection with fzf if no branch specified)


### PR DESCRIPTION
## Summary
- `wt checkout` (and its fzf interactive selection) now handles branches that only exist on a remote: it creates a local branch tracking the matching remote-tracking ref instead of erroring with "Branch does not exist".
- Errors clearly if more than one remote has a branch by the same name.

## Test plan
- [x] `wt checkout <remote-only-branch>` creates a worktree with a new local branch tracking `origin/<branch>`
- [x] `wt checkout` with fzf, selecting a remote-only branch, works the same way
- [ ] `wt checkout <local-branch>` still uses the existing local branch (unchanged behavior)
- [ ] `wt checkout <nonexistent>` still errors with the "use wt new" hint

🤖 Generated with [Claude Code](https://claude.com/claude-code)