### PR TITLE
git: enable submodule-aware config for this repo

### DIFF
--- a/git/install.sh
+++ b/git/install.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+#
+# Set repo-local git config for the dotfiles repo itself.
+# Mostly tuned for the submodule workflow (e.g. Doom Emacs as a submodule):
+# pulls recurse, status/diff surface submodule movement, push refuses to
+# leave the superproject pointing at unpushed submodule commits.
+
+set -e
+
+cd "$(dirname "$0")/.."
+
+git config --local submodule.recurse true
+git config --local status.submoduleSummary true
+git config --local diff.submodule log
+git config --local fetch.recurseSubmodules on-demand
+git config --local push.recurseSubmodules check


### PR DESCRIPTION
## Summary
- Adds `git/install.sh` which sets repo-local git config tuned for the submodule workflow (e.g. bumping the Doom Emacs submodule via PR and pulling on another machine)
- Runs as part of `script/bootstrap` on fresh clones and on every `bin/dot` invocation (all settings are idempotent)

### Config applied
| Setting | Effect |
|---|---|
| `submodule.recurse=true` | `pull` / `checkout` recurse into submodules — pulling the dotfiles repo updates the Doom checkout automatically |
| `status.submoduleSummary=true` | `git status` shows which submodules moved and by how many commits |
| `diff.submodule=log` | `git diff` shows the submodule's commit log between old/new SHA instead of `Subproject commit abc..def` |
| `fetch.recurseSubmodules=on-demand` | `fetch` grabs new submodule commits when the superproject references them |
| `push.recurseSubmodules=check` | refuses to push if the superproject points at a submodule SHA that isn't on the submodule's remote |

### Caveats
- These are repo-local, not shared via committed gitconfig (git refuses to read in-tree config for security). Existing clones pick the settings up next `bin/dot` run; new clones via `script/bootstrap`.
- `submodule.recurse` does not auto-init brand-new submodules added by someone else — those still need a one-time `git submodule update --init --recursive`.

## Test plan
- [ ] `bin/dot` runs cleanly and `git/install.sh` is invoked by `script/install`
- [ ] `git config --local --list | grep -E 'submodule|recurseSubmodules|submoduleSummary'` shows all five values after run
- [ ] Re-running `bin/dot` is a no-op for these settings (idempotent)
- [ ] After bumping the Doom submodule SHA on one machine, `git pull` on another updates `emacs/.emacs.d.symlink` automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)